### PR TITLE
Bump version

### DIFF
--- a/clock.cabal
+++ b/clock.cabal
@@ -1,5 +1,5 @@
 name:          clock
-version:       0.4.1.2
+version:       0.4.1.3
 stability:     stable
 synopsis:      High-resolution clock functions: monotonic, realtime, cputime.
 description:   A package for convenient access to high-resolution clock and


### PR DESCRIPTION
Hi Certin,

Sorry to bug you with this triviality, but it seems you forgot to update the version in git after releasing 0.4.1.3 on hackage. This leads to confusion if one tries to reinstall from the current git (it installs an older version rather than reinstalling the latest one).

Thanks,
Mihaly
