### PR TITLE
fixes bug in function `abs`

### DIFF
--- a/System/Clock.hsc
+++ b/System/Clock.hsc
@@ -179,8 +179,9 @@ instance Num TimeSpec where
       normalize $ TimeSpec (xs * ys) (xn * yn)
   negate (TimeSpec xs xn) =
       normalize $ TimeSpec (negate xs) (negate xn)
-  abs (TimeSpec xs xn) =
-      normalize $ TimeSpec (abs xs) (signum xs * xn)
+  abs (TimeSpec xs xn)
+	| xs == 0   = normalize $ TimeSpec 0 xn
+	| otherwise = normalize $ TimeSpec (abs xs) (signum xs * xn)
   signum (normalize -> TimeSpec xs yn)
     | signum xs == 0 = TimeSpec 0 (signum yn)
     | otherwise = TimeSpec 0 (signum xs)


### PR DESCRIPTION
When the seconds value of a TimeSpec-typed value is `0`, the `signum`
function in the function definition of `abs` returns a `0`. This in
turn zeroes the nanoseconds value, even if it was originally non-zero.