### PR TITLE
Add benchmarks for getTime

### DIFF
--- a/bench/benchmarks.hs
+++ b/bench/benchmarks.hs
@@ -1,0 +1,18 @@
+module Main (main) where
+
+import Criterion.Main
+import System.Clock
+
+main :: IO ()
+main = defaultMain [
+    bgroup "getTime" [
+        bench "Monotonic" $ whnfIO (getTime Monotonic)
+      , bench "Realtime" $ whnfIO (getTime Realtime)
+      , bench "ProcessCPUTime" $ whnfIO (getTime ProcessCPUTime)
+      , bench "ThreadCPUTime" $ whnfIO (getTime ThreadCPUTime)
+      , bench "MonotonicRaw" $ whnfIO (getTime MonotonicRaw)
+      , bench "Boottime" $ whnfIO (getTime Boottime)
+      , bench "MonotonicCoarse" $ whnfIO (getTime MonotonicCoarse)
+      , bench "RealtimeCoarse" $ whnfIO (getTime RealtimeCoarse)
+      ]
+  ]

--- a/clock.cabal
+++ b/clock.cabal
@@ -93,3 +93,15 @@ test-suite test
       , tasty >= 0.10
       , tasty-quickcheck
       , clock
+
+benchmark benchmarks
+    type:
+      exitcode-stdio-1.0
+    hs-source-dirs:
+      bench
+    main-is:
+      benchmarks.hs
+    build-depends:
+        base >= 4 && < 5
+      , criterion
+      , clock


### PR DESCRIPTION
I have only run these benchmarks on Linux so far, but if there's interest in making them compatible with other platforms, and you can give me some pointers, I'll try to make them cross-platform compatible too.