### PR TITLE
Cache the result of QueryPerformanceFrequency

### DIFF
--- a/cbits/hs_clock_win32.c
+++ b/cbits/hs_clock_win32.c
@@ -31,9 +31,15 @@ static void to_timespec_from_100ns(ULONGLONG t_100ns, long long *t)
 void hs_clock_win32_gettime_monotonic(long long* t)
 {
    LARGE_INTEGER time;
-   LARGE_INTEGER frequency;
+   static LARGE_INTEGER frequency;
+   static int hasFreq = 0;
+
    QueryPerformanceCounter(&time);
-   QueryPerformanceFrequency(&frequency);
+   if (!hasFreq)
+   {
+      hasFreq = 1;
+      QueryPerformanceFrequency(&frequency);
+   }
    // seconds
    t[0] = time.QuadPart / frequency.QuadPart;
    // nanos =


### PR DESCRIPTION
The API docs at https://msdn.microsoft.com/en-us/library/windows/desktop/ms644905(v=vs.85).aspx recommend caching the result.

On my benchmark of asking for the time 20M times the time taken goes from 2.60s to 2.41s, providing a small but useful speedup.