### PR TITLE
Fix linking issues on 32-bit Windows

### DIFF
--- a/clock.cabal
+++ b/clock.cabal
@@ -74,6 +74,10 @@ library
       c-sources:         cbits/hs_clock_darwin.c
     if os(windows)
       c-sources:         cbits/hs_clock_win32.c
+
+      -- See https://ghc.haskell.org/trac/ghc/ticket/15094
+      if arch(i386)
+        extra-libraries: gcc_s_dw2-1
     include-dirs:        cbits
     ghc-options:         -O3 -Wall
 


### PR DESCRIPTION
Since `clock` compiles its bundled C code with `-O3`, `gcc` will optimize a division followed by a modulo calculation to a single `divmod`. On 32-bit Windows, this requires a library call found in `libgcc`, so it is necessary to link against it. (Not doing so caused #50.)

For more information, see the discussion at https://ghc.haskell.org/trac/ghc/ticket/15094.