### PR TITLE
Fix linking issues on 32-bit Windows

### DIFF
--- a/cbits/hs_clock_win32.c
+++ b/cbits/hs_clock_win32.c
@@ -28,6 +28,10 @@ static void to_timespec_from_100ns(ULONGLONG t_100ns, long long *t)
     t[1] = 100*(long)(t_100ns % 10000000UL);
 }
 
+/* See https://ghc.haskell.org/trac/ghc/ticket/15094 */
+#if defined(_WIN32) && !defined(_WIN64)
+__attribute__((optimize("-fno-expensive-optimizations")))
+#endif
 void hs_clock_win32_gettime_monotonic(long long* t)
 {
    LARGE_INTEGER time;


### PR DESCRIPTION
Since clock compiles its bundled C code with `-O3`, `gcc` will optimize a division followed by a modulo calculation to a single 64-bit `divmod`. This isn't natively supported on 32-bit architectures, which can lead
to bizarre linking errors (as in #50). To avoid this, we simply prevent `gcc` from doing this optimization using an `__attribute__`.

For more information, see the discussion at https://ghc.haskell.org/trac/ghc/ticket/15094.