### PR TITLE
Mark clock_gettime and clock_getres as unsafe FFI

### DIFF
--- a/System/Clock.hsc
+++ b/System/Clock.hsc
@@ -128,8 +128,8 @@ foreign import ccall hs_clock_win32_getres_threadtime :: Ptr TimeSpec -> IO ()
 foreign import ccall hs_clock_darwin_gettime :: #{type clock_id_t} -> Ptr TimeSpec -> IO ()
 foreign import ccall hs_clock_darwin_getres  :: #{type clock_id_t} -> Ptr TimeSpec -> IO ()
 #else
-foreign import ccall clock_gettime :: #{type clockid_t} -> Ptr TimeSpec -> IO ()
-foreign import ccall clock_getres  :: #{type clockid_t} -> Ptr TimeSpec -> IO ()
+foreign import ccall unsafe clock_gettime :: #{type clockid_t} -> Ptr TimeSpec -> IO ()
+foreign import ccall unsafe clock_getres  :: #{type clockid_t} -> Ptr TimeSpec -> IO ()
 #endif
 
 #if defined(_WIN32)


### PR DESCRIPTION
These calls do not block nor do they call back into Haskell call: it's
safe to marke them as `unsafe`. The safe FFI overhead is huge. Please
refer to the numbers below. If we're trying to measure things on such
granular level, it makes no sense to take 80-100ns hit of the safe FFI
wrapper and waste time.

Before:
```
benchmarking getTime/Monotonic
time                 99.87 ns   (99.81 ns .. 99.94 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 99.88 ns   (99.84 ns .. 99.94 ns)
std dev              147.1 ps   (75.24 ps .. 295.7 ps)

benchmarking getTime/Realtime
time                 102.3 ns   (101.7 ns .. 103.1 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 102.0 ns   (101.8 ns .. 102.5 ns)
std dev              1.024 ns   (307.0 ps .. 2.033 ns)

benchmarking getTime/ProcessCPUTime
time                 393.4 ns   (392.5 ns .. 394.4 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 393.2 ns   (392.5 ns .. 394.3 ns)
std dev              2.993 ns   (2.027 ns .. 4.424 ns)

benchmarking getTime/ThreadCPUTime
time                 387.8 ns   (387.2 ns .. 388.8 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 387.4 ns   (387.1 ns .. 388.0 ns)
std dev              1.251 ns   (469.2 ps .. 1.977 ns)

benchmarking getTime/MonotonicRaw
time                 350.1 ns   (347.6 ns .. 353.1 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 349.1 ns   (347.8 ns .. 351.1 ns)
std dev              5.392 ns   (3.928 ns .. 6.854 ns)
variance introduced by outliers: 17% (moderately inflated)

benchmarking getTime/Boottime
time                 349.4 ns   (349.0 ns .. 350.3 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 349.2 ns   (349.0 ns .. 350.2 ns)
std dev              1.121 ns   (243.9 ps .. 2.684 ns)

benchmarking getTime/MonotonicCoarse
time                 85.81 ns   (85.35 ns .. 86.52 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 85.63 ns   (85.43 ns .. 86.09 ns)
std dev              990.8 ps   (533.0 ps .. 1.620 ns)
variance introduced by outliers: 11% (moderately inflated)

benchmarking getTime/RealtimeCoarse
time                 90.81 ns   (90.74 ns .. 90.93 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 90.93 ns   (90.74 ns .. 91.67 ns)
std dev              1.095 ns   (93.33 ps .. 2.308 ns)
variance introduced by outliers: 12% (moderately inflated)
```

After:
```
benchmarking getTime/Monotonic
time                 24.30 ns   (24.27 ns .. 24.33 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 24.31 ns   (24.28 ns .. 24.40 ns)
std dev              161.0 ps   (39.24 ps .. 278.8 ps)

benchmarking getTime/Realtime
time                 24.38 ns   (24.36 ns .. 24.39 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 24.37 ns   (24.36 ns .. 24.38 ns)
std dev              26.68 ps   (21.63 ps .. 33.58 ps)

benchmarking getTime/ProcessCPUTime
time                 271.4 ns   (271.4 ns .. 271.4 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 271.5 ns   (271.4 ns .. 271.7 ns)
std dev              445.7 ps   (136.6 ps .. 834.4 ps)

benchmarking getTime/ThreadCPUTime
time                 265.7 ns   (265.6 ns .. 265.7 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 265.6 ns   (265.6 ns .. 265.7 ns)
std dev              198.9 ps   (151.3 ps .. 269.0 ps)

benchmarking getTime/MonotonicRaw
time                 224.8 ns   (224.7 ns .. 224.9 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 224.7 ns   (224.6 ns .. 224.8 ns)
std dev              261.7 ps   (228.1 ps .. 300.2 ps)

benchmarking getTime/Boottime
time                 228.1 ns   (228.1 ns .. 228.2 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 228.3 ns   (228.2 ns .. 228.3 ns)
std dev              207.8 ps   (190.2 ps .. 232.3 ps)

benchmarking getTime/MonotonicCoarse
time                 13.27 ns   (13.27 ns .. 13.27 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.27 ns   (13.27 ns .. 13.27 ns)
std dev              4.875 ps   (4.032 ps .. 5.751 ps)

benchmarking getTime/RealtimeCoarse
time                 13.71 ns   (13.65 ns .. 13.79 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.66 ns   (13.64 ns .. 13.71 ns)
std dev              114.3 ps   (35.92 ps .. 210.1 ps)

Benchmark benchmarks: FINISH
```

Probably a similar change should be made for OSX but I don't know the
details on that platform nor can I test it: if someone can do it, I
think it'd be very good to do so. I don't know about Windows at all.