### PR TITLE
"Seconds" RealFrac instance

### DIFF
--- a/clock.cabal
+++ b/clock.cabal
@@ -76,6 +76,7 @@ library
                          ForeignFunctionInterface
                          ScopedTypeVariables
                          ViewPatterns
+                         GeneralizedNewtypeDeriving
     if os(windows)
       c-sources:         cbits/hs_clock_win32.c
     include-dirs:        cbits


### PR DESCRIPTION
So my PR #67 makes the Num instance consistent in the following way:
* fromInteger interprets the integral as nanoseconds
* the unit element of multiplication (*) is "one nanosecond" (TimeSpec 0 1)
* TimeSpec is an instance of Integral

IMO this is the simpler and more useful approach. But there is another Num instance defined in the style of [Fixed](https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Fixed.html) in the following way:
* fromInteger interprets the integral as seconds
* the unit element of multiplication (*) is "one second" (TimeSpec 1 0)
* It is an instance of RealFrac

I wrote this as a wrapper newtype `Seconds` here in this PR. The behavior is chosen to be similar to Float/Double, so #49 should be solved by using this newtype instead of TimeSpec.

The name "Seconds" is inspired by [extra](https://hackage.haskell.org/package/extra-1.7.9/docs/System-Time-Extra.html), I don't know if it's really a good name for it.