### PR TITLE
Fix #73: revise bounds on base to >= 4.4

### DIFF
--- a/clock.cabal
+++ b/clock.cabal
@@ -68,8 +68,8 @@ flag llvm
 library
     default-language: Haskell2010
     if impl (ghc < 7.6)
-      build-depends:       base >= 4.4 && <= 5, ghc-prim
-    build-depends:       base >= 2 && <= 5
+      build-depends:     ghc-prim
+    build-depends:       base >= 4.4 && < 5
     exposed-modules:     System.Clock
     default-extensions:          DeriveGeneric
                          DeriveDataTypeable
@@ -95,7 +95,7 @@ test-suite test
     main-is:
       test.hs
     build-depends:
-        base >= 4 && < 5
+        base
       , tasty >= 0.10
       , tasty-quickcheck
       , clock
@@ -109,6 +109,6 @@ benchmark benchmarks
     main-is:
       benchmarks.hs
     build-depends:
-        base >= 4 && < 5
+        base
       , criterion
       , clock


### PR DESCRIPTION
Fix #73: revise bounds on base to >= 4.4

Also:
- delete repeated (redundant) bounds on base in test-suite and
  benchmark
- fix upper bound to < 5 (rather than <= 5, which isn't what you want)