### PR TITLE
Fix #72: break dependency cycle with constraint: tasty -clock

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+-- Andreas Abel, 2022-02-07, issue #72: Fix cyclic dependencies.
+-- The default would be tasty +clock, but this creates a dependency cycle.
+constraints:
+  tasty -clock


### PR DESCRIPTION
Fix #72: break dependency cycle with `constraint: tasty -clock`

Without that flag, `cabal build --enable-tests` fails with
```
rejecting: tasty:+clock (cyclic dependencies; conflict set: clock, tasty, tasty-quickcheck)
```

Note that CI fails for this PR because of #77: https://github.com/andreasabel/clock/actions/runs/1807463703