### PR TITLE
Fix #75: require base >= 4.7, bump to 0.8.3, CHANGELOG stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.8.3
+
+- Dropped support for GHC < 7.8.
+- Tested with GHC 7.8 - 9.2.
+- TODO: new module `System.Clock.Seconds`
+- TODO: new functions
+- TODO: other changes

--- a/clock.cabal
+++ b/clock.cabal
@@ -1,6 +1,6 @@
 cabal-version: >= 1.10
 name:          clock
-version:       0.8.2
+version:       0.8.3
 stability:     stable
 synopsis:      High-resolution clock functions: monotonic, realtime, cputime.
 description:   A package for convenient access to high-resolution clock and
@@ -65,6 +65,9 @@ tested-with:
   GHC == 7.10.3
   GHC == 7.8.4
 
+extra-source-files:
+  CHANGELOG.md
+
 
 source-repository head
     type:      git
@@ -77,13 +80,13 @@ flag llvm
 
 
 library
-    default-language: Haskell2010
-    if impl (ghc < 7.6)
-      build-depends:     ghc-prim
-    build-depends:       base >= 4.4 && < 5
+    build-depends:       base >= 4.7 && < 5
+
     exposed-modules:     System.Clock
-                        System.Clock.Seconds
-    default-extensions:          DeriveGeneric
+                         System.Clock.Seconds
+
+    default-language:    Haskell2010
+    default-extensions:  DeriveGeneric
                          DeriveDataTypeable
                          ForeignFunctionInterface
                          ScopedTypeVariables
@@ -99,8 +102,8 @@ library
 
 
 test-suite test
-    default-language: Haskell2010
-    default-extensions: ScopedTypeVariables
+    default-language:    Haskell2010
+    default-extensions:  ScopedTypeVariables
                          GeneralizedNewtypeDeriving
                          StandaloneDeriving
     type:


### PR DESCRIPTION
Fix #75: 
- require base >= 4.7 due to #68 / #69
- new functions require bump to at least 0.8.3 according to the Haskell PVP
- a CHANGELOG was missing so far; I added a stub, but it needs to be fleshed out