### PR TITLE
Fix `RealFrac Seconds` instance 

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -6,7 +6,7 @@ jobs:
   wasi:
     runs-on: ubuntu-latest
     env:
-      GHC_WASM_META_REV: 5a5c10c3b7e2f9f55bb2f40601cb20c9eb599bb5
+      GHC_WASM_META_REV: 895f7067e1d4c918a45559da9d2d6a403a690703
       FLAVOUR: '9.6'
     steps:
     - name: Setup WASI GHC

--- a/System/Clock/Seconds.hs
+++ b/System/Clock/Seconds.hs
@@ -50,7 +50,7 @@ instance Fractional Seconds where
 
 instance RealFrac Seconds where
   properFraction (Seconds (TimeSpec s ns))
-    | s >= 0 = (fromIntegral s, Seconds $ TimeSpec 0 ns)
+    | s >= 0 || ns == 0 = (fromIntegral s, Seconds $ TimeSpec 0 ns)
     | otherwise = (fromIntegral (s+1), Seconds $ TimeSpec (-1) ns)
 
 -- | The 'getTime' function shall return the current value for the

--- a/cabal.project
+++ b/cabal.project
@@ -4,3 +4,8 @@ packages: .
 -- The default would be tasty +clock, but this creates a dependency cycle.
 constraints:
   tasty -clock
+
+-- otherwise, we get CI failures
+if impl(ghc ==8.2.*)
+  package text
+    flags: -simdutf


### PR DESCRIPTION
Closes #87, see https://github.com/corsis/clock/issues/87#issuecomment-1576119653 for an analysis.

Consider the law of [`properFraction`](https://hackage.haskell.org/package/base-4.18.0.0/docs/GHC-Real.html#v:properFraction):

> The function [`properFraction`](https://hackage.haskell.org/package/base-4.18.0.0/docs/GHC-Real.html#v:properFraction) takes a real fractional number `x` and returns a pair `(n,f)` such that `x = n+f`, and:
>
> - `n` is an integral number with the same sign as `x`; and
> - `f` is a fraction with the same type and sign as `x`, and with absolute value less than `1`.

Before this change, we had
```haskell
 Λ properFraction (-1 :: Seconds)
(0,Seconds {toTimeSpec = TimeSpec {sec = -1, nsec = 0}})
```
which violates the second property above, as `f = Seconds {toTimeSpec = TimeSpec {sec = -1, nsec = 0}}` has absolute value `1`, which is not *less* than `1`.

With this change, we correctly get:
```haskell
 Λ properFraction (-1 :: Seconds)
(-1,Seconds {toTimeSpec = TimeSpec {sec = 0, nsec = 0}})
```